### PR TITLE
Fix. Prevent buffer persistence after floating window closure

### DIFF
--- a/lua/todoforge/window.lua
+++ b/lua/todoforge/window.lua
@@ -43,7 +43,8 @@ function M.open(todo_file)
 	local buf_handle = vim.fn.bufadd(todo_file)
 	vim.fn.bufload(buf_handle)
 
-	vim.bo[buf_handle].buflisted = true
+	vim.bo[buf_handle].buflisted = false
+	vim.bo[buf_handle].bufhidden = "wipe"
 	vim.bo[buf_handle].swapfile = false
 	vim.bo[buf_handle].modified = false
 


### PR DESCRIPTION
## What this PR does
This PR fixes an issue where opening TodoForge with <leader>tdf left the todo.md buffer loaded in the background. After quitting the floating window, the buffer would still exist and require manual closing with :q.

## Changes made
- Marked the todo.md buffer as unlisted (buflisted = false), so it no longer shows up in :ls.
- Set bufhidden = "wipe" to automatically clean up the buffer once the floating window is closed.
- Preserved existing options (swapfile = false, modified = false).

## Result
When the user quits the floating TodoForge window, the buffer is properly cleaned up and does not persist in the background. No manual :q is needed anymore.