### PR TITLE
Add. footer and footer_pos window opts

### DIFF
--- a/lua/todoforge/window.lua
+++ b/lua/todoforge/window.lua
@@ -20,6 +20,12 @@ local function win_config()
 		border = "rounded",
 		title = "TodoForge",
 		title_pos = "center",
+		footer = string.format(
+			"%s Save  |  %s Quit",
+			config.options.keymaps.float.save,
+			config.options.keymaps.float.quit
+		),
+		footer_pos = "right",
 	}
 end
 


### PR DESCRIPTION
### Summary
Adds `footer` and `footer_pos` support to floating window config.  

### Changes
- Added `footer` and `footer_pos` options in `win_config`.
- Default footer displays save and quit keymaps from config.

### Why
Improves UX by showing contextual hints at the bottom of the floating window.  

Closes: #2 